### PR TITLE
Add C# specific stack handling

### DIFF
--- a/addons/tracer/StackHandler.cs
+++ b/addons/tracer/StackHandler.cs
@@ -1,0 +1,35 @@
+using Godot;
+using System.Diagnostics;
+
+public partial class StackHandler : GodotObject
+{
+	public string GetModulePath()
+	{
+		string modulePath = "unknown";
+		StackTrace st = new StackTrace(true);
+		if (st.FrameCount > 6)
+		{
+			StackFrame sf = st.GetFrame(6);
+			modulePath = sf.GetFileName();
+			string rootDir = ProjectSettings.GlobalizePath("res://");
+			// This substring is necessary in order to remove the OS path from the module's
+			// filepath.
+			// i.e. remove "C:/GodotProjects/Game" from "C:/GodotProjects/Game/Scenes/Main/Main.cs"
+			// ProjectSettings.LocalizePath(...) doesn't seem to work.
+			modulePath = modulePath.Substring(rootDir.Length);
+		}
+		return modulePath;
+	}
+
+	public string GetFunctionName()
+	{
+		string functionName = "unknown";
+		StackTrace st = new StackTrace(true);
+		if (st.FrameCount > 6)
+		{
+			StackFrame sf = st.GetFrame(6);
+			functionName = sf.GetMethod().Name;
+		}
+		return functionName;
+	}
+}

--- a/addons/tracer/StackHandler.cs
+++ b/addons/tracer/StackHandler.cs
@@ -17,6 +17,11 @@ public partial class StackHandler : GodotObject
 			// i.e. remove "C:/GodotProjects/Game" from "C:/GodotProjects/Game/Scenes/Main/Main.cs"
 			// ProjectSettings.LocalizePath(...) doesn't seem to work.
 			modulePath = modulePath.Substring(rootDir.Length);
+			// Also convert Windows-style backslashes to Godot standard forward slashes if present.
+			if (modulePath.Contains("\\"))
+			{
+				modulePath = modulePath.Replace("\\", "/");
+			}
 		}
 		return modulePath;
 	}

--- a/addons/tracer/tracer.gd
+++ b/addons/tracer/tracer.gd
@@ -20,18 +20,26 @@ class Trace:
 		Time.get_datetime_string_from_system()
 	)
 	var thread_id := 1
+	var _has_mono: bool = Engine.has_singleton("GodotSharp")
 
 	func _init(
 		msg: String, level: Level, new_thread_id := 0
 	) -> void:
 		self.msg = msg
 		self.level = level
-		var st = get_stack()
-		if st.size() > 2:
-			module = st[2].source.trim_prefix("res://")
-			function_name = st[2].function
+		if _has_mono:
+			# C#-specific stack handling
+			var mono_sh_script = load("res://addons/tracer/StackHandler.cs")
+			var mono_stack_handler = mono_sh_script.new()
+			module = mono_stack_handler.GetModulePath()
+			function_name = mono_stack_handler.GetFunctionName()
 		else:
-			function_name = "unknown"
+			var st = get_stack()
+			if st.size() > 2:
+				module = st[2].source.trim_prefix("res://")
+				function_name = st[2].function
+			else:
+				function_name = "unknown"
 		thread_id = new_thread_id
 
 

--- a/addons/tracer/tracer.gd
+++ b/addons/tracer/tracer.gd
@@ -27,19 +27,18 @@ class Trace:
 	) -> void:
 		self.msg = msg
 		self.level = level
-		if _has_mono:
+		var st = get_stack()
+		if st.size() > 2:
+			module = st[2].source.trim_prefix("res://")
+			function_name = st[2].function
+		elif _has_mono:
 			# C#-specific stack handling
 			var mono_sh_script = load("res://addons/tracer/StackHandler.cs")
 			var mono_stack_handler = mono_sh_script.new()
 			module = mono_stack_handler.GetModulePath()
 			function_name = mono_stack_handler.GetFunctionName()
 		else:
-			var st = get_stack()
-			if st.size() > 2:
-				module = st[2].source.trim_prefix("res://")
-				function_name = st[2].function
-			else:
-				function_name = "unknown"
+			function_name = "unknown"
 		thread_id = new_thread_id
 
 


### PR DESCRIPTION
# Add C# specific stack handling
The C# utility for handling stack traces is different than GDScript's (as detailed [here](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/c_sharp_differences.html).) This change implements a small C# GodotObject to allow Tracer to resolve the correct module and function/method names using `System.Diagnostics.StackTrace` rather than GDScript's `print_stack` when the editor supports it.

## Testing
Editor versions:
- [x] 4.1.3.stable
- [X] 4.1.1.stable.mono
Validated that the StackHandler script will not be called if the plugin is used in a non-mono version of the editor and that the module and function names are resolved correctly when Tracer is called from a C# script.